### PR TITLE
fix: include okta user type to user object instead of using scope key…

### DIFF
--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -7,6 +7,10 @@ module.exports = {
 
   scopeKey: 'scope',
 
+  // -- Proxy Server --
+
+  apiServer: undefined,
+
   // -- Redirects --
 
   rewriteRedirects: true,

--- a/lib/schemes/oktaplus.js
+++ b/lib/schemes/oktaplus.js
@@ -126,6 +126,13 @@ export default class OktaPlusScheme {
       url: this.options.userinfo_endpoint
     })
 
+    if(this.$auth.options.apiServer) {
+      const userType = await this.$auth.requestWith(this.name, {
+        url: `${this.$auth.options.apiServer}/api/users/${user?.sub}/type`
+      })
+      user.userType = userType?.name
+    }
+
     this.$auth.setUser(user)
   }
 


### PR DESCRIPTION
Adds proxied endpoint to app that returns okta user type and assigns to user object, for role validation instead of using scope key attribute.